### PR TITLE
VERSION should be a build arg, not an envvar, since it's used solely …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM busybox:latest
 MAINTAINER Hubert Dąbrowski <h@dabrow.org>
 
-ENV ACME_STATE_DIR /data
-ENV VERSION 0.0.49
+ENV ACME_STATE_DIR="/data"
+ARG VERSION="0.0.59"
 
 ADD https://github.com/hlandau/acme/releases/download/v${VERSION}/acmetool-v${VERSION}-linux_amd64.tar.gz /opt/
 RUN tar -xf /opt/acmetool-v${VERSION}-linux_amd64.tar.gz -C /opt && \


### PR DESCRIPTION
…at buildtime. Ref: https://docs.docker.com/engine/reference/builder/#arg